### PR TITLE
Fix egregious errors

### DIFF
--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -132,7 +132,7 @@ def main():
     parser.add_argument("--compresslevel", '-m', type=int, default=5,
                         help="bz2 compression level when encoding")
 
-    parser.add_argument("--editor", "-E", default="",
+    parser.add_argument("--editor", "-E",
                         help="Editor to use for pasting packets")
 
     args = parser.parse_args()
@@ -165,15 +165,16 @@ def main():
             elif 'EDITOR' in os.environ:
                 editor = os.environ['EDITOR']
             else:
-                for program in ['mimeopen', 'nano', 'vi', 'emacs', 'micro']:
+                for program in ['mimeopen', 'nano', 'vi', 'emacs',
+                                'micro', 'notepad', 'notepad++']:
                     editor = which(program)
-                    if editor != '':  # something worked
+                    if editor is not None:  # something worked
                         break
 
-            if editor == '':
-                quit("Could not find a suitable editor." +
-                     "Please specify with '--editor'" +
-                     "or set the EDITOR variable in your shell.")
+                if editor is None:
+                    quit("Could not find a suitable editor." +
+                         "Please specify with '--editor'" +
+                         "or set the EDITOR variable in your shell.")
             stderr.write("editor is %s\n" % editor)
 
             tmpfile = tempfile.mkstemp()[1]


### PR DESCRIPTION
Fix crash if editor cannot be found
Add notepad to editor list (for windows users)
Change default for args.editor from '' to None

Cherry picked from https://github.com/charlesdaniels/bitshuffle/commit/e4c77e5ad1e345428df3fb547f8d0e2dfc6593b6, 
https://github.com/charlesdaniels/bitshuffle/commit/749725c9f7a073d1f8c39570d13c3a6051363b8b,
https://github.com/charlesdaniels/bitshuffle/commit/11f82da797c5534a4c0062f103c7844a9b93d2e7, 
and https://github.com/charlesdaniels/bitshuffle/commit/ded3686a195e9b9dc1d813a97bf3ccff1fcd7c8c