### PR TITLE
Refactor do_test

### DIFF
--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -132,7 +132,7 @@ def main():
     parser.add_argument("--compresslevel", '-m', type=int, default=5,
                         help="bz2 compression level when encoding")
 
-    parser.add_argument("--editor", "-E", default="",
+    parser.add_argument("--editor", "-E",
                         help="Editor to use for pasting packets")
 
     args = parser.parse_args()
@@ -165,15 +165,16 @@ def main():
             elif 'EDITOR' in os.environ:
                 editor = os.environ['EDITOR']
             else:
-                for program in ['mimeopen', 'nano', 'vi', 'emacs', 'micro']:
+                for program in ['mimeopen', 'nano', 'vi', 'emacs',
+                                'micro', 'notepad', 'notepad++']:
                     editor = which(program)
-                    if editor != '':  # something worked
+                    if editor is not None:  # something worked
                         break
 
-            if editor == '':
-                quit("Could not find a suitable editor." +
-                     "Please specify with '--editor'" +
-                     "or set the EDITOR variable in your shell.")
+                if editor is None:
+                    quit("Could not find a suitable editor." +
+                         "Please specify with '--editor'" +
+                         "or set the EDITOR variable in your shell.")
             stderr.write("editor is %s\n" % editor)
 
             tmpfile = tempfile.mkstemp()[1]

--- a/smoketest/do_test.sh
+++ b/smoketest/do_test.sh
@@ -8,7 +8,8 @@
 
 PARENT_DIR="$(dirname "$0")"
 BITSHUFFLE="$PARENT_DIR/../bitshuffle.py"
-
+BITSHUFFLE2="python2 $BITSHUFFLE"
+BITSHUFFLE3="python3 $BITSHUFFLE"
 if [ ! -x "$BITSHUFFLE" ] ; then
 	echo "FATAL: '$BITSHUFFLE' does not exist"
 	exit 9999
@@ -18,88 +19,68 @@ make_random () {
 	dd if=/dev/urandom of="$1" bs=1024 count=64 > /dev/null 2>&1
 }
 
-printf "Running tests...\n"
+do_test () {
+	# requires $1 to be a string literal of the test you wish to execute.
+	# see below for examples
+	LOG_FILE="/tmp/$(uuidgen)"
+	TEMPFILE_SRC="/tmp/$(uuidgen)"
+	TEMPFILE_DST="/tmp/$(uuidgen)"
+	make_random "$TEMPFILE_SRC"
+	TEMPFILE_SRC_SHA="$(shasum "$TEMPFILE_SRC" 2>&1 | cut -d ' ' -f 1)"
+	eval "$1" > "$LOG_FILE" 2>&1 
+	TEMPFILE_DST_SHA="$(shasum "$TEMPFILE_DST" 2>&1 | cut -d ' ' -f 1)"
+	if [ "$TEMPFILE_DST_SHA" = "$TEMPFILE_SRC_SHA" ] ; then
+		echo "PASSED"
+	else
+		printf "FAILED\n\n"
+
+		printf "\t$TEMPFILE_SRC_SHA does not match $TEMPFILE_DST_SHA\n"
+		echo
+		while read -r ln  ; do
+			printf "\t$ln\n"
+		done < "$LOG_FILE"
+		printf "\n\n"
+		TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
+	fi
+	rm -f "$LOG_FILE"
+	rm -f "$TEMPFILE_SRC"
+	rm -f "$TEMPFILE_DST"
+}
+
+all_tests () {
+
+    printf "Basic encode/decode test... "
+    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+
+    printf "Basic encode/decode test (large chunk size)... "
+    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 16384 | \
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+
+
+    printf "Basic encode/decode test (small chunk size)... "
+    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 8 | \
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+
+
+    printf "Double encode/decode test... "
+    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
+        $BITSHUFFLE --encode | $BITSHUFFLE --decode | \
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+
+}
+
+echo "Running tests..."
 
 TESTS_FAILED=0
 
-printf "Basic encode/decode test... "
-LOG_FILE="/tmp/$(uuidgen)"
-TEMPFILE_SRC="/tmp/$(uuidgen)"
-TEMPFILE_DST="/tmp/$(uuidgen)"
-make_random "$TEMPFILE_SRC"
-TEMPFILE_SRC_SHA="$(shasum "$TEMPFILE_SRC" 2>&1 | cut -d ' ' -f 1)"
-"$BITSHUFFLE" --encode --input "$TEMPFILE_SRC" | \
-	"$BITSHUFFLE" --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1
-TEMPFILE_DST_SHA="$(shasum "$TEMPFILE_DST" 2>&1 | cut -d ' ' -f 1)"
-if [ "$TEMPFILE_DST_SHA" = "$TEMPFILE_SRC_SHA" ] ; then
-	printf "PASSED\n"
-else
-	printf "FAILED\n"
-	printf "\n"
-	printf "\t$TEMPFILE_SRC_SHA does not match $TEMPFILE_DST_SHA\n"
-	printf "\n"
-	while read -r ln  ; do
-		printf "\t$ln\n"
-	done < "$LOG_FILE"
-	printf "\n\n"
-	TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
-fi
-rm -f "$LOG_FILE"
-rm -f "$TEMPFILE_SRC"
-rm -f "$TEMPFILE_DST"
+printf "\nRunning Python2 tests...\n"
+BITSHUFFLE="$BITSHUFFLE2"
+all_tests
 
-printf "Basic encode/decode test (large chunk size)... "
-LOG_FILE="/tmp/$(uuidgen)"
-TEMPFILE_SRC="/tmp/$(uuidgen)"
-TEMPFILE_DST="/tmp/$(uuidgen)"
-make_random "$TEMPFILE_SRC"
-TEMPFILE_SRC_SHA="$(shasum "$TEMPFILE_SRC" 2>&1 | cut -d ' ' -f 1)"
-"$BITSHUFFLE" --encode --input "$TEMPFILE_SRC" --chunksize 16384 | \
-	"$BITSHUFFLE" --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1
-TEMPFILE_DST_SHA="$(shasum "$TEMPFILE_DST" 2>&1 | cut -d ' ' -f 1)"
-if [ "$TEMPFILE_DST_SHA" = "$TEMPFILE_SRC_SHA" ] ; then
-	printf "PASSED\n"
-else
-	printf "FAILED\n"
-	printf "\n"
-	printf "\t$TEMPFILE_SRC_SHA does not match $TEMPFILE_DST_SHA\n"
-	printf "\n"
-	while read -r ln  ; do
-		printf "\t$ln\n"
-	done < "$LOG_FILE"
-	printf "\n\n"
-	TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
-fi
-rm -f "$LOG_FILE"
-rm -f "$TEMPFILE_SRC"
-rm -f "$TEMPFILE_DST"
+printf "\nRunning Python3 tests...\n"
+BITSHUFFLE="$BITSHUFFLE3"
+all_tests
 
-printf "Basic encode/decode test (small chunk size)... "
-LOG_FILE="/tmp/$(uuidgen)"
-TEMPFILE_SRC="/tmp/$(uuidgen)"
-TEMPFILE_DST="/tmp/$(uuidgen)"
-make_random "$TEMPFILE_SRC"
-TEMPFILE_SRC_SHA="$(shasum "$TEMPFILE_SRC" 2>&1 | cut -d ' ' -f 1)"
-"$BITSHUFFLE" --encode --input "$TEMPFILE_SRC" --chunksize 8 | \
-	"$BITSHUFFLE" --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1
-TEMPFILE_DST_SHA="$(shasum "$TEMPFILE_DST" 2>&1 | cut -d ' ' -f 1)"
-if [ "$TEMPFILE_DST_SHA" = "$TEMPFILE_SRC_SHA" ] ; then
-	printf "PASSED\n"
-else
-	printf "FAILED\n"
-	printf "\n"
-	printf "\t$TEMPFILE_SRC_SHA does not match $TEMPFILE_DST_SHA\n"
-	printf "\n"
-	while read -r ln  ; do
-		printf "\t$ln\n"
-	done < "$LOG_FILE"
-	printf "\n\n"
-	TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
-fi
-rm -f "$LOG_FILE"
-rm -f "$TEMPFILE_SRC"
-rm -f "$TEMPFILE_DST"
-
-printf "\n"
-printf "$TESTS_FAILED tests failed\n"
+printf "\n$TESTS_FAILED tests failed\n"
 exit $TESTS_FAILED


### PR DESCRIPTION
Modify bitshuffle to work with both python 2 and 3
Test both python 2 and 3
Add double encode/decode test
Only show output on failing tests

Cherry-picked from https://github.com/charlesdaniels/bitshuffle/commit/6a858c4a9dd8a853c673b671ff29bcc74406099f, https://github.com/charlesdaniels/bitshuffle/commit/1f52f9ef57f2506329e694c1ad1ea87a964f363d, https://github.com/charlesdaniels/bitshuffle/commit/51f1503e3012b91fcda952ff22a50e944fbd3118, and https://github.com/charlesdaniels/bitshuffle/commit/0eaade3404115e5c1f1091d08666929d3354f461
