### PR TITLE
Infer encode/decode (major changes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
-
 language: python
 python: 3.5
-
 os:
-    - linux
-
+- linux
 install:
-    - pip3 install pycodestyle
-
+- pip3 install pycodestyle
 script:
-    - ./smoketest/do_test.sh
-    - pycodestyle --ignore E221,E203 ./bitshuffle.py
-
+- "./smoketest/do_test.sh"
+- pycodestyle --ignore E221,E203 ./bitshuffle.py
 notifications:
-    email:
-        on_success: never
-        on_failure: always
+  email:
+    on_success: never
+    on_failure: always
+deploy:
+  provider: releases
+  api_key:
+    secure: O6I+bNW8eaABty0yAiQQOajH6HmjhmVmF+g9sdr/8q5YnSW+lxfFJK+AP9mWLEK1WbJeoSHZhyUH8eLMjFi2t4QugKIV3BxKWgbhoWUJ+xTmlv21wUSaagGGxzsmL2PD1UUgkUsZ/F4ZLW4zvJ0HZ5i/usKT0QtrM35H7heq2m15W6O/q+2Ie6hO89vV/Uf1mC8wU+VbfDXgggqzQxWFFFUcx4QlMT59vvaPtA3dzdwbET1OxTTk/Ghnh9QOaSrFFNQmGGAAP77ze5DffedZxfpBzPBegWBySFiIVtHkwb9KER5hyIAd/Tzgl4kUYm3yte/Vpv2TI+SYFkPEV2MqwvWHJ+h9MHknCM3JyncEOX4Xl06EEmaJbADt2xLpQ8z0H6D7wmqKgmRJFdgZs/By7yHRJM6zP5BzGLqdq2O+4p2JRik1ibvSfeFt4kYGEp7shb7UekM475hCZK1pdcJAQOFgbSBB6ax1jszzGTd/5yTKGiXwtkS2++9rLWyZzs7avg5VhQaiLK3fl+4WoEZJJeBLpVu/zeHwJIThE306yrSoW2OU78Qwy6Xbpnb13BoiVBlS3M/hiKdkknQ/UEaQ4hICRX4a43zQL3H5zH3hx3TZNXIQduPcpDHTnkIHugPnrNzH4SK5evtT0i4k1ICbdhCU2uFaZ77fIFSeXX44xsA=
+  file: bitshuffle.py
+  skip_cleanup: true
+  on:
+    tags: true

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,7 @@
+CONTRIBUTORS
+LICENSE
+README.rst
+setup.cfg
+setup.py
+bitshuffle.py
+

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -173,9 +173,10 @@ def main():
 
     args = parser.parse_args()
 
+    # Checks if no parameters were passed
     if len(sys.argv[1:]) == 0:
-        parser.print_help()
-        exit(0)
+        parser.print_usage()
+        sys.exit(1)
 
     elif args.version:
         print("Version: bitshuffle v%s" % version)

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -212,7 +212,7 @@ def main():
         infile = args.input
         # set to True for infile to be deleted after decoding
         is_tmp = False
-        if stdin.isatty() and args.input is '/dev/stdin':
+        if stdin.isatty() and args.input == '/dev/stdin':
             # ask the user to paste the packets into $VISUAL
             is_tmp = True
 
@@ -221,7 +221,7 @@ def main():
                 tf.write("Paste your BitShuffle packets in this file. You " +
                          "do not need to delete this message.\n\n")
                 tf.flush()
-            subprocess.call([editor, tmpfile])
+            subprocess.call([args.editor, tmpfile])
             infile = tmpfile
 
         with open(infile, 'r') as f:
@@ -297,7 +297,7 @@ def infer_mode(args):
         return args
 
     elif any((args.compresstype, args.compresslevel,
-              args.chunklevel, args.filename)):
+              args.chunksize, args.filename)):
         args.encode = True
 
     # this is a submenu: could specify editor to compose
@@ -316,6 +316,8 @@ def infer_mode(args):
     else:
         parser.print_help()
         quit(1)
+
+    return args
 
 
 def set_defaults(args):

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -251,21 +251,25 @@ def main():
 
     # Main
     if args.encode:
+
         if args.compresstype not in ['bz2', 'gzip']:
             parser.print_help()
             sys.exit(1)
 
-        with open(args.input, 'rb') as f:
-            packets = encode_file(f, args.chunksize, args.compresslevel,
-                                  args.compresstype, args.filename)
-            with open(args.output, 'w') as of:
-                for p in packets:
-                    of.write(p)
-                    of.write("\n\n")
+        if check_for_file(args.input):
+            with open(args.input, 'rb') as f:
+                packets = encode_file(f, args.chunksize, args.compresslevel,
+                                      args.compresstype, args.filename)
+                with open(args.output, 'w') as of:
+                    for p in packets:
+                        of.write(p)
+                        of.write("\n\n")
 
-                of.flush()
-
+                    of.flush()
+        else:
+            quit('Error: Input file not found')
     elif args.decode:
+
         infile = args.input
         # set to True for infile to be deleted after decoding
         is_tmp = False
@@ -379,6 +383,14 @@ def verify(data, given_hash):
                      "may want to investigate.\n")
         return False
     return True
+
+
+def check_for_file(filename):
+    try:
+        open(filename)
+        return True
+    except FileNotFoundError:
+        return False
 
 
 if __name__ == "__main__":

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -215,26 +215,13 @@ def main():
         if stdin.isatty() and args.input == '/dev/stdin':
             # ask the user to paste the packets into $VISUAL
             is_tmp = True
-            if args.editor:
-                editor = args.editor
-            elif 'VISUAL' in os.environ:
-                editor = os.environ['VISUAL']
-            elif 'EDITOR' in os.environ:
-                editor = os.environ['EDITOR']
-            else:
-                for program in ['mimeopen', 'nano', 'vi', 'emacs',
-                                'micro', 'notepad', 'notepad++']:
-                    editor = which(program)
-                    if editor is not None:  # something worked
-                        break
+            if not args.editor:
+                args.editor = find_editor()
+            if not check_for_file(args.editor):
+                print("Editor %s not found" % args.editor)
+                sys.exit(4)
 
-                if editor is None:
-                    print("Could not find a suitable editor." +
-                          "Please specify with '--editor'" +
-                          "or set the EDITOR variable in your shell.")
-                    sys.exit(1)
-
-            stderr.write("editor is %s\n" % editor)
+            stderr.write("editor is %s\n" % args.editor)
 
             tmpfile = tempfile.mkstemp()[1]
             with open(tmpfile, 'w') as tf:
@@ -390,7 +377,7 @@ def verify(data, given_hash):
 
 def check_for_file(filename):
     try:
-        open(filename)
+        open(filename).close()
         return True
     except FileNotFoundError:
         return False

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # .SHELLDOC
 #

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -170,8 +170,6 @@ def main():
                         help="Type of compression to use when encoding. "
                              "Defaults to bz2. " +
                              "Currently supported: 'bz2', 'gzip'")
-    parser.add_argument("--editor", "-E",
-                        help="Editor to use for pasting packets")
 
     args = parser.parse_args()
 
@@ -232,9 +230,11 @@ def main():
                         break
 
                 if editor is None:
-                    quit("Could not find a suitable editor." +
-                         "Please specify with '--editor'" +
-                         "or set the EDITOR variable in your shell.")
+                    print("Could not find a suitable editor." +
+                          "Please specify with '--editor'" +
+                          "or set the EDITOR variable in your shell.")
+                    sys.exit(1)
+
             stderr.write("editor is %s\n" % editor)
 
             tmpfile = tempfile.mkstemp()[1]

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -170,6 +170,8 @@ def main():
                         help="Type of compression to use when encoding. "
                              "Defaults to bz2. " +
                              "Currently supported: 'bz2', 'gzip'")
+    parser.add_argument("--editor", "-E",
+                        help="Editor to use for pasting packets")
 
     args = parser.parse_args()
 
@@ -216,6 +218,24 @@ def main():
         if stdin.isatty() and args.input == '/dev/stdin':
             # ask the user to paste the packets into $VISUAL
             is_tmp = True
+            if args.editor:
+                editor = args.editor
+            elif 'VISUAL' in os.environ:
+                editor = os.environ['VISUAL']
+            elif 'EDITOR' in os.environ:
+                editor = os.environ['EDITOR']
+            else:
+                for program in ['mimeopen', 'nano', 'vi', 'emacs',
+                                'micro', 'notepad', 'notepad++']:
+                    editor = which(program)
+                    if editor is not None:  # something worked
+                        break
+
+                if editor is None:
+                    quit("Could not find a suitable editor." +
+                         "Please specify with '--editor'" +
+                         "or set the EDITOR variable in your shell.")
+            stderr.write("editor is %s\n" % editor)
 
             tmpfile = tempfile.mkstemp()[1]
             with open(tmpfile, 'w') as tf:

--- a/bitshuffle.py
+++ b/bitshuffle.py
@@ -170,7 +170,6 @@ def main():
                         help="Type of compression to use when encoding. "
                              "Defaults to bz2. " +
                              "Currently supported: 'bz2', 'gzip'")
-
     args = parser.parse_args()
 
     # Checks if no parameters were passed

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+./setup.py sdist
+./setup.py bdist_wheel
+printf 'Upload project to PyPI? [no]: '
+read confirm
+if [[ $confirm = y* ]] ; then twine upload dist/*; fi
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_wheel]
+# works for both python 2 and 3 without modification
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+from bitshuffle import version
+from setuptools import setup
+from setuptools import find_packages
+
+short_description = \
+    'Transmit data over applications that restrict the files that can be sent'
+
+long_description = '''
+BitShuffle is a protocol for transmitting arbitrary bitstreams
+over bitstream-hostile transmission mediums.
+In particular, it is designed for use with applications
+such as instant messaging programs or e-mail
+which restrict the files that can be sent.
+It supports multiple files and binary data,
+and automatically compares the checksum
+of decoded files to the hash transmitted.
+'''.lstrip()  # remove leading newline
+
+classifiers = [
+    # see http://pypi.python.org/pypi?:action=list_classifiers
+    'Development Status :: 3 - Alpha',
+    'Environment :: Console',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: BSD License',
+    'Operating System :: POSIX'
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
+    'Topic :: Communications :: File Sharing'
+    ]
+
+setup(name="bitshuffle",
+      version=version,
+      description=short_description,
+      long_description=long_description,
+      author="Charles Daniels",
+      author_email="cdaniels@fastmail.com",
+      url="https://github.com/charlesdaniels/bitshuffle",
+      license='BSD',
+      classifiers=classifiers,
+      keywords='checksum hash internet transmit file',
+      packages=find_packages(exclude=['smoketest']),
+      platforms=['POSIX'],
+      entry_points={'console_scripts': ['bitshuffle=bitshuffle:main']}
+      )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ classifiers = [
     'Environment :: Console',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
-    'Operating System :: POSIX'
+    'Operating System :: POSIX',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3',

--- a/smoketest/do_test.sh
+++ b/smoketest/do_test.sh
@@ -27,13 +27,12 @@ do_test () {
 	TEMPFILE_DST="/tmp/$(uuidgen)"
 	make_random "$TEMPFILE_SRC"
 	TEMPFILE_SRC_SHA="$(shasum "$TEMPFILE_SRC" 2>&1 | cut -d ' ' -f 1)"
-	eval "$1" > "$LOG_FILE" 2>&1 
+	eval "$1" > "$LOG_FILE" 2>&1
 	TEMPFILE_DST_SHA="$(shasum "$TEMPFILE_DST" 2>&1 | cut -d ' ' -f 1)"
 	if [ "$TEMPFILE_DST_SHA" = "$TEMPFILE_SRC_SHA" ] ; then
 		echo "PASSED"
 	else
 		printf "FAILED\n\n"
-
 		printf "\t$TEMPFILE_SRC_SHA does not match $TEMPFILE_DST_SHA\n"
 		echo
 		while read -r ln  ; do
@@ -51,32 +50,31 @@ all_tests () {
 
     printf "Basic encode/decode test... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "Basic encode/decode test (large chunk size)... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 16384 | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
 
     printf "Basic encode/decode test (small chunk size)... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 8 | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
-
-
-    printf "Double encode/decode test... "
-    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --encode | $BITSHUFFLE --decode | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "GZIP test... "
     do_test '$BITSHUFFLE --encode --compresstype "gzip" --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
 
     printf "BZIP test... "
     do_test '$BITSHUFFLE --encode --compresstype "bz2" --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
-        
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+
+    printf "Double encode/decode test... "
+    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
+        $BITSHUFFLE --encode | $BITSHUFFLE --decode | \
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+
 }
 
 echo "Running tests..."


### PR DESCRIPTION
Assign defaults *after* inferring argument

-  If arguments are specified, easier to infer
-  If not, it's clear that no change was made (as opposed to the user specifying the default)
-  Use dictionary (called 'defaults') to specify
-  Note: filename has to be evaluated second because it depends on input

Quit if no arguments given
Many layers of checks to infer arguments
Decisions made as follows: (assuming encode/decode not passed)

-  editor given        -> decode
-  compresstype given  -> encode
-  compresslevel given -> encode
-  chunklevel given    -> encode
-  filename given      -> encode
-  no output:          -> encode       (why?)
-  no input and interactive  -> decode (why?)
-  input and not interactive -> quit with error
-  input and output          -> quit with error

Other refactoring:
find_editor() is its own function (simplifies logic by a great deal)