### PR TITLE
Added shellcheck, misc. CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,15 @@ python:
 sudo: required
 addons:
   apt:
+    sources:
+    - debian-sid  # needed for shellcheck
     packages:
-    - realpath # required by script
-    - cabal-install
-    - ghc
+    - shellcheck
+
 os: linux
 install:
   - pip install pycodestyle setuptools
   - gem install travis --no-rdoc --no-ri
-
-  # https://github.com/koalaman/shellcheck/wiki/TravisCI
-  - curl -L "https://raw.githubusercontent.com/Lin-Buo-Ren/Utilities-for-Travis-CI/master/Build%20and%20Setup%20ShellCheck's%20Latest%20Release.bash" -o setup_shellcheck.bash
-  - chmod +x setup_shellcheck.bash
-  - ./setup_shellcheck.bash --without-root
-
-before_cache:
-- rm $HOME/.cabal/logs/build.log
-
-cache:
-  directories:
-  - $HOME/.cabal
 
 script:
 - "./scripts/test_end2end.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,39 @@ language: python
 python:
     - "2.7"
     - "3.6"
-    - "nightly"
+
 # Sudo is required so that steup.py can be tested (TODO: investigate using
 # a virtualenv instead?)
 sudo: required
+addons:
+  apt:
+    packages:
+    - realpath # required by script
+    - cabal-install
+    - ghc
 os: linux
 install:
   - pip install pycodestyle setuptools
   - gem install travis --no-rdoc --no-ri
+
+  # https://github.com/koalaman/shellcheck/wiki/TravisCI
+  - curl -L "https://raw.githubusercontent.com/Lin-Buo-Ren/Utilities-for-Travis-CI/master/Build%20and%20Setup%20ShellCheck's%20Latest%20Release.bash" -o setup_shellcheck.bash
+  - chmod +x setup_shellcheck.bash
+  - ./setup_shellcheck.bash --without-root
+
+before_cache:
+- rm $HOME/.cabal/logs/build.log
+
+cache:
+  directories:
+  - $HOME/.cabal
 
 script:
 - "./scripts/test_end2end.sh"
 - "./scripts/test_setup_py.sh"
 - "./scripts/test_argument_options.sh"
 - "./scripts/test_pycodestyle.sh"
+- "./scripts/test_shellcheck.sh"
 
 notifications:
   email:

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+"$(git rev-parse --show-toplevel)"/scripts/pre_commit_check.sh
+exit $?

--- a/scripts/pre_commit_check.sh
+++ b/scripts/pre_commit_check.sh
@@ -8,8 +8,9 @@
 #
 # .ENDOC
 
-. "$(dirname $0)/realpath.sh"
-PARENT_DIR="$(realpath_sh $(dirname "$0"))"
+# shellcheck disable=SC1090
+. "$(dirname "$0")/realpath.sh"
+PARENT_DIR="$(realpath_sh "$(dirname "$0")")"
 
 "$PARENT_DIR/test_end2end.sh"
 RET1=$?
@@ -19,15 +20,18 @@ RET2=$?
 RET3=$?
 "$PARENT_DIR/test_travis_lint.sh"
 RET4=$?
+"$PARENT_DIR/test_shellcheck.sh"
+RET5=$?
 
-TOTAL_FAILED=$(echo "$RET1 + $RET2 + $RET3 + $RET4" | bc)
+TOTAL_FAILED=$(echo "$RET1 + $RET2 + $RET3 + $RET4 + $RET5" | bc)
 echo ""
+# shellcheck disable=SC2039
 echo "- - - - -"
 echo "$TOTAL_FAILED total test failures"
-if [ $TOTAL_FAILED -gt 0 ] ; then
+if [ "$TOTAL_FAILED" -gt 0 ] ; then
 	echo "One or more problems found, please fix these before committing."
 else
 	echo "Everything looks ok, proceed with commit."
 fi
 
-exit $TOTAL_FAILED
+exit "$TOTAL_FAILED"

--- a/scripts/pypi.sh
+++ b/scripts/pypi.sh
@@ -3,5 +3,5 @@
 ./setup.py bdist_wheel
 printf 'Upload project to PyPI? [no]: '
 read -r confirm
-if [[ $confirm = y* ]] ; then twine upload dist/*; fi
+if $(echo "$confirm" | grep '^y.*') ; then twine upload dist/*; fi
 

--- a/scripts/pypi.sh
+++ b/scripts/pypi.sh
@@ -2,6 +2,6 @@
 ./setup.py sdist
 ./setup.py bdist_wheel
 printf 'Upload project to PyPI? [no]: '
-read confirm
+read -r confirm
 if [[ $confirm = y* ]] ; then twine upload dist/*; fi
 

--- a/scripts/pypi.sh
+++ b/scripts/pypi.sh
@@ -3,5 +3,5 @@
 ./setup.py bdist_wheel
 printf 'Upload project to PyPI? [no]: '
 read -r confirm
-if $(echo "$confirm" | grep '^y.*') ; then twine upload dist/*; fi
+if echo "$confirm" | grep '^y.*'; then twine upload dist/*; fi
 

--- a/scripts/realpath.sh
+++ b/scripts/realpath.sh
@@ -38,7 +38,7 @@
 #
 #  ---------
 #
-#  This software used and modified from its original version on 2016-12-31 by
+#  This software used and modified from its original version on 2017-12-19 by
 #  Charles Daniels.
 #
 #  Modified 2017-12-18 by Joshua Nelson
@@ -53,8 +53,8 @@ realpath_sh() {
 resolve_symlinks() {
     _assert_no_path_cycles "$@" || return
 
-    local dir_context path
     path=$(readlink -- "$1")
+    # shellcheck disable=SC2181
     if [ $? -eq 0 ]; then
         dir_context=$(dirname -- "$1")
         _resolve_symlinks "$(_prepend_dir_context_if_necessary "$dir_context" "$path")" "$@"
@@ -79,8 +79,6 @@ _prepend_path_if_relative() {
 }
 
 _assert_no_path_cycles() {
-    local target path
-
     target=$1
     shift
 
@@ -104,10 +102,9 @@ _canonicalize_dir_path() {
 }
 
 _canonicalize_file_path() {
-    local dir file
     dir=$(dirname -- "$1")
     file=$(basename -- "$1")
-    printf '%s/%s\n' $(_canonicalize_dir_path "$dir") "$file"
+    printf '%s/%s\n' "$(_canonicalize_dir_path "$dir")" "$file"
 }
 
 # Optionally, you may also want to include:
@@ -131,7 +128,7 @@ _emulated_readlink() {
 }
 
 _gnu_stat_readlink() {
-    local output
+    output
     output=$(stat -c %N -- "$1" 2>/dev/null) &&
 
     printf '%s\n' "$output" |

--- a/scripts/realpath.sh
+++ b/scripts/realpath.sh
@@ -128,7 +128,6 @@ _emulated_readlink() {
 }
 
 _gnu_stat_readlink() {
-    output
     output=$(stat -c %N -- "$1" 2>/dev/null) &&
 
     printf '%s\n' "$output" |

--- a/scripts/test_argument_options.sh
+++ b/scripts/test_argument_options.sh
@@ -7,8 +7,9 @@
 
 # .ENDOC
 
-. "$(dirname $0)/realpath.sh"
-TEST_DIR="$(realpath_sh $(dirname "$0"))"
+# shellcheck disable=SC1090
+. "$(dirname "$0")/realpath.sh"
+TEST_DIR="$(realpath_sh "$(dirname "$0")")"
 BITSHUFFLE="$TEST_DIR/../bitshuffle/bitshuffle.py"
 TESTS_FAILED=0
 
@@ -23,24 +24,25 @@ fi
 print_log_file() {
 # takes 1 parameter, a text file
         while read -r line; do
-                printf "\t$line\n"
-        done < $1
+                printf "\t%s\n" "$line"
+        done < "$1"
         printf "\n\n"
 }
 
 
 expect_usage_error () {
-        LOG_FILE="/tmp/`uuidgen`"
+        LOG_FILE="/tmp/$(uuidgen)"
+        # shellcheck disable=SC2068
         $BITSHUFFLE $@ > "$LOG_FILE" 2>&1
-        if grep -q "usage: .*" $LOG_FILE; then
+        if grep -q "usage: .*" "$LOG_FILE" ; then
                 echo "PASSED"
         else
                 printf "FAILED\n\n"
 
-                printf "\t'usage: .*' does not match logfile\n\n" 
-                print_log_file $LOG_FILE
-                TESTS_FAILED=`echo "$TESTS_FAILED + 1" | bc`
-                rm -f $LOG_FILE
+                printf "\t'usage: .*' does not match logfile\n\n"
+                print_log_file "$LOG_FILE"
+                TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
+                rm -f "$LOG_FILE"
         fi
 }
 
@@ -71,7 +73,7 @@ expect_usage_error -t gmander
 #        rm -f $LOG_FILE
 #fi
 
-LOG_FILE="/tmp/`uuidgen`"
+LOG_FILE="/tmp/$(uuidgen)"
 printf "When given bad input, prints file not found... "
 $BITSHUFFLE --input /nonexistent/nope > "$LOG_FILE" 2>&1
 if grep -i 'could not open' < "$LOG_FILE" > /dev/null 2>&1 ; then
@@ -79,10 +81,10 @@ if grep -i 'could not open' < "$LOG_FILE" > /dev/null 2>&1 ; then
 else
     printf "FAILED\n\n"
 
-    print_log_file $LOG_FILE
-    TESTS_FAILED=`echo $TESTS_FAILED + 1 | bc`
-    rm -f $LOG_FILE
+    print_log_file "$LOG_FILE"
+    TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
+    rm -f "$LOG_FILE"
 fi
 
-printf "\n$TESTS_FAILED tests failed.\n"
-exit $TESTS_FAILED
+printf "\n%s tests failed.\n" "$TESTS_FAILED"
+exit "$TESTS_FAILED"

--- a/scripts/test_end2end.sh
+++ b/scripts/test_end2end.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+# shellcheck disable=SC2016
+# shellcheck disable=SC1004
+
+# SC2016 is disabled because we have lots of string literals that get eval-ed
+# later in the script.
+
+# SC1004 is disabled because there are a number of places where we want
+# backslash + newline litera in this script.
 
 # .SHELLDOC
 
@@ -6,11 +14,17 @@
 
 # .ENDOC
 
-. "$(dirname $0)/realpath.sh"
-PARENT_DIR="$(realpath_sh $(dirname "$0"))"
+# shellcheck disable=SC1090
+. "$(dirname "$0")/realpath.sh"
+PARENT_DIR="$(realpath_sh "$(dirname "$0")")"
 PROJECT_ROOT="$PARENT_DIR/.."
 BITSHUFFLE_FILE="$PROJECT_ROOT/bitshuffle/bitshuffle.py"
+
+# shellcheck disable=SC2034
 BITSHUFFLE="python $BITSHUFFLE_FILE"
+# this variable appears unused to ShellCheck because it is only used inside
+# of eval-ed code.
+
 if [ ! -f "$BITSHUFFLE_FILE" ] ; then
 	echo "FATAL: '$BITSHUFFLE_FILE' does not exist"
 	exit 9999
@@ -35,10 +49,10 @@ do_test () {
 	else
 		printf "FAILED\n\n"
 
-		printf "\t$TEMPFILE_SRC_SHA does not match $TEMPFILE_DST_SHA\n"
+		printf "\t%s does not match %s\n" "$TEMPFILE_SRC_SHA" "$TEMPFILE_DST_SHA"
 		echo
 		while read -r ln  ; do
-			printf "\t$ln\n"
+			printf "\t%n\n" "$ln"
 		done < "$LOG_FILE"
 		printf "\n\n"
 		TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
@@ -95,5 +109,5 @@ TESTS_FAILED=0
 
 all_tests
 
-printf "\n$TESTS_FAILED tests failed\n"
+printf "\n%s tests failed\n" "$TESTS_FAILED"
 exit $TESTS_FAILED

--- a/scripts/test_setup_py.sh
+++ b/scripts/test_setup_py.sh
@@ -10,8 +10,9 @@
 set -e
 set -u
 
-. "$(dirname $0)/realpath.sh"
-PARENT_DIR="$(realpath_sh $(dirname "$0"))"
+# shellcheck disable=SC1090
+. "$(dirname "$0")/realpath.sh"
+PARENT_DIR="$(realpath_sh "$(dirname "$0")")"
 PROJECT_TLD="$PARENT_DIR"
 echo "project root seems to be: $PROJECT_TLD"
 

--- a/scripts/test_shellcheck.sh
+++ b/scripts/test_shellcheck.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-# .SCRIPTDOC
+# .SHELLDOC
 #
-# Run PyCodeStyle on every python file under the project root.
+# Checks all shell scripts under the project TLD for compliance with
+# ShellCheck.
 #
 # .ENDOC
 
@@ -16,10 +17,12 @@ PROJECT_ROOT="$PARENT_DIR/.."
 TOTAL=0
 RETCODE=0
 TEMPFILE="/tmp/$(uuidgen)"
-find "$PROJECT_ROOT" -print | while read -r line ; do
-	if file "$line" | grep -i 'python script' > /dev/null 2>&1 ; then
-		echo "pycodestyle for file '$line': "
-		pycodestyle "$line"
+# the grep -v '.git' prevents git's default hooks from causing ShellCheck
+# defects.
+find "$PROJECT_ROOT" -print | grep -v '.git' | while read -r line ; do
+	if file "$line" | grep -i 'shell script' > /dev/null 2>&1 ; then
+		echo "shellcheck for file '$line': "
+		shellcheck "$line"
 		RETCODE=$?
 		echo ""
 
@@ -30,6 +33,6 @@ find "$PROJECT_ROOT" -print | while read -r line ; do
 done
 
 TOTAL="$(cat "$TEMPFILE")"
-echo "$TOTAL total defects across all files"
+echo "$TOTAL defective files"
 rm -f "$TEMPFILE"
 exit "$TOTAL"

--- a/scripts/test_shellcheck.sh
+++ b/scripts/test_shellcheck.sh
@@ -22,7 +22,7 @@ TEMPFILE="/tmp/$(uuidgen)"
 find "$PROJECT_ROOT" -print | grep -v '.git' | while read -r line ; do
 	if file "$line" | grep -i 'shell script' > /dev/null 2>&1 ; then
 		echo "shellcheck for file '$line': "
-		shellcheck "$line"
+		shellcheck -s sh "$line"
 		RETCODE=$?
 		echo ""
 

--- a/scripts/test_travis_lint.sh
+++ b/scripts/test_travis_lint.sh
@@ -2,17 +2,18 @@
 printf "\nChecking for valid .travis.yml config... "
 
 LOG_FILE="/tmp/$(uuidgen)"
-. "$(dirname $0)/realpath.sh"
-PARENT_DIR="$(realpath_sh $(dirname "$0"))"
+# shellcheck disable=SC1090
+. "$(dirname "$0")/realpath.sh"
+PARENT_DIR="$(realpath_sh "$(dirname "$0")")"
 PROJECT_ROOT="$PARENT_DIR/.."
 
-if travis lint "$PROJECT_ROOT/.travis.yml" 1>$LOG_FILE 2>&1; then
+if travis lint "$PROJECT_ROOT/.travis.yml" 1> "$LOG_FILE" 2>&1; then
     echo "PASSED"
     exit 0
 else
     echo "FAILED"
     while read -r ln; do
-        printf "\t$ln\n"
+        printf "\t%s\n" "$ln"
     done < "$LOG_FILE"
     exit 1
 fi

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -4,7 +4,7 @@
 # be verbose
 set -ev
 
-OLDCWD=`pwd`
+OLDCWD="$(pwd)"
 WINE_PYTHON="wine $HOME/.wine/drive_c/python35/python.exe"
 # use 32 bit wine
 export WINEARCH=win32
@@ -46,7 +46,7 @@ $WINE_PYTHON -m pip install pyinstaller
 pip install pyinstaller
 
 # actually make the files
-cd $OLDCWD
+cd "$OLDCWD"
 $WINE_PYTHON -m PyInstaller --one-file --distpath dist/windows bitshuffle.py
 python -m PyInstaller --one-file --distpath dist/linux bitshuffle.py
 


### PR DESCRIPTION
* revert counting mechanism for test_pycodestyle

	* The method which was added by @jyn514 caused the loop to exit
	after the first iteration. This patch revers to the old, ugly method of
	using a temporary file to store the defect counter. We can switch to a
	different method if a better one is found, but it has to work across all
	the files in the project, not just the first one.

* add test_shellcheck.sh

* brought all existing scripts into compliance with shellcheck

* disable python 'nightly' version for travis

	* Turning off Python's nightly build as a version to test with
	because I don't want regressions in Python to cause build
	failures for us.