### PR TITLE
No longer require sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
     - "2.7"
     - "3.6"
 
-# Sudo is required so that setup.py can be tested (TODO: investigate using
-# a virtualenv instead?)
-sudo: required
+# speed up builds
+sudo: false
+
 addons:
   apt:
     sources:
@@ -34,10 +34,10 @@ notifications:
 
 before_deploy:
 - "export MY_UID=$(id -u)"
-- "if ! [ -d dist ]; then sudo mkdir dist; fi"
-- "sudo chown -R $MY_UID dist"
-- "if ! [ -d build ]; then sudo mkdir build; fi"
-- "sudo chown -R $MY_UID build"
+- "if ! [ -d dist ]; then mkdir dist; fi"
+- "chown -R $MY_UID dist"
+- "if ! [ -d build ]; then mkdir build; fi"
+- "chown -R $MY_UID build"
 # makes a linux executable in dist/bitshuffle
 - "pyinstaller --onefile bitshuffle/bitshuffle.py"
 

--- a/scripts/test_setup_py.sh
+++ b/scripts/test_setup_py.sh
@@ -49,16 +49,7 @@ do_test () {
 		exit 999
 	fi
 
-	INSTALL="$PYTHON_BIN ./setup.py install"
-    if ! [ -w /usr/local/bin ]; then INSTALL="sudo $INSTALL"; fi
-	if ! $INSTALL ; then
-		echo "FAIL: failed to install BitShuffle with Python '$PYTHON_BIN'"
-		exit 1
-	fi
-
-	cd /
-
-	if ! "$PYTHON_BIN" -m bitshuffle.bitshuffle --version ; then
+	if ! "$PYTHON_BIN" -m pip install . --version ; then
 		echo "FAIL: failed to execute BitShuffle with Python '$PYTHON_BIN'"
 		exit 2
 	fi

--- a/scripts/test_setup_py.sh
+++ b/scripts/test_setup_py.sh
@@ -14,18 +14,7 @@ set -u
 . "$(dirname "$0")/realpath.sh"
 PARENT_DIR="$(realpath_sh "$(dirname "$0")")"
 PROJECT_TLD="$PARENT_DIR"
-echo "project root seems to be: $PROJECT_TLD"
-
-cd "$PROJECT_TLD"
-if [ ! -e "./bitshuffle" ] ; then
-	echo "PANIC: failed to locate bitshuffle module directory"
-	exit 999
-fi
-
-if [ ! -e "./setup.py" ] ; then
-	echo "PANIC: failed to locate setup.py"
-	exit 999
-fi
+echo "DEBUG: project root seems to be: $PROJECT_TLD"
 
 # .DOCUMENTS do_test
 #
@@ -40,23 +29,23 @@ fi
 do_test () {
 
 	PYTHON_BIN="$(which "$1")"
-	if [ ! -x "$PYTHON_BIN" ] ; then
+	if [ -z "$PYTHON_BIN" ] || [ ! -x "$PYTHON_BIN" ] ; then
 		echo "PANIC: failed to locate Python binary at '$PYTHON_BIN'"
 		exit 999
 	fi
 
 	echo "Testing BitShuffle setup.py with '$PYTHON_BIN'"
 
-        cd "$PROJECT_TLD"
+	cd "$PROJECT_TLD"
 	if [ ! -e "./bitshuffle" ] ; then
 		echo "PANIC: failed to locate bitshuffle module directory"
-		echo "cwd is: '$(pwd)'"
+		echo "DEBUG: cwd is: '$(pwd)'"
 		exit 999
 	fi
 
 	if [ ! -e "./setup.py" ] ; then
 		echo "PANIC: failed to locate setup.py"
-		echo "cwd is: '$(pwd)'"
+		echo "DEBUG: cwd is: '$(pwd)'"
 		exit 999
 	fi
 
@@ -74,7 +63,7 @@ do_test () {
 		exit 2
 	fi
 
-	echo "Test finished without error."
+	echo "INFO: Test finished without error."
 
 }
 


### PR DESCRIPTION
This should [speed up builds considerably](https://docs.travis-ci.com/user/reference/trusty/#Container-based-with-sudo%3A-false). This should also allow `setup.py` to be tested locally with little hassle. This was [tested](https://travis-ci.org/charlesdaniels/bitshuffle/builds/343613240) with a static release.

Nothing controversial here.