### PR TITLE
Remove `input` and `output` arguments

### DIFF
--- a/bitshuffle/__main__.py
+++ b/bitshuffle/__main__.py
@@ -78,6 +78,7 @@ def main():
     """A tool for encoding and decoding arbitrary binary data as
 ASCII text suitable for transmission over common communication protocols"""
 
+    global stdin
     parser = create_parser()
     args = parser.parse_args()
 
@@ -110,7 +111,7 @@ ASCII text suitable for transmission over common communication protocols"""
         else:
             compress = gzip.compress
 
-        packets = encode(stdin, args.size, args.compresslevel,
+        packets = encode(stdin, args.chunksize, args.compresslevel,
                          compress, args.message)
         for packet in packets:
             stdout.write(packet)
@@ -140,9 +141,9 @@ ASCII text suitable for transmission over common communication protocols"""
                                "You do not need to delete this message.\n\n")
                 tempfile.flush()
             subprocess.call([args.editor, tmpfile])
-            args.input = open(tmpfile, 'r')
+            stdin = open(tmpfile, 'r')
 
-        payload, checksum_ok = decode(args.input.read())
+        payload, checksum_ok = decode(stdin.read())
         try:
             # python 3
             stdout.buffer.write(payload)

--- a/bitshuffle/__main__.py
+++ b/bitshuffle/__main__.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-"""A tool for encoding and decoding arbitrary binary data as
-ASCII text suitable for transmission over common communication protocols"""
+'''
+BitShuffle command-line client. Supports encoding & decoding.
+Run with --help for usage information.
+'''
 
 from __future__ import division, generators, print_function, absolute_import
 
@@ -31,7 +33,7 @@ except NameError:
 
 def create_parser():
     '''Argument options for CLI tool'''
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=main.__doc__)
 
     action = parser.add_mutually_exclusive_group()
     action.add_argument("--encode", "-e", action="store_true",
@@ -69,6 +71,89 @@ def create_parser():
                         help="Override message displayed in every packet." +
                         " (default: " + DEFAULT_MSG + ")")
     return parser
+
+
+def main():
+
+    """A tool for encoding and decoding arbitrary binary data as
+ASCII text suitable for transmission over common communication protocols"""
+
+    global stdin
+    parser = create_parser()
+    args = parser.parse_args()
+
+    # Checks if no parameters were passed
+    if not argv[1:] and stdin.isatty():
+        parser.print_help()
+        if DEBUG:
+            exit_with_error(1, 0)
+        else:
+            exit_successfully()
+
+    # Encode & Decode inference
+    args = infer_mode(args)
+
+    # Set default values. Note that this ensures that args.input and
+    # args.output are open file handles (or crashes the script if not).
+    args = set_defaults(args)
+
+    # Main
+    if args.encode:
+        if args.compresstype not in ['bz2', 'gzip']:
+            parser.print_help()
+            exit_with_error(2, args.compresstype)
+        elif args.compresstype == 'bz2':
+            compress = bz2.compress
+        else:
+            compress = gzip.compress
+
+        packets = encode(stdin, args.chunksize, args.compresslevel,
+                         compress, args.message)
+        for packet in packets:
+            stdout.write(packet)
+            stdout.write("\n\n")
+
+        exit_successfully()
+
+    else:
+
+        # set to True for infile to be deleted after decoding
+        is_tmp = False
+        if stdin.isatty():
+            # ask the user to paste the packets into $VISUAL
+            is_tmp = True
+            if not args.editor:
+                args.editor = find_editor()
+
+            if not check_for_file(args.editor):
+                exit_with_error(103, args.editor)
+
+            if DEBUG:
+                stderr.write("editor is %s\n" % args.editor)
+
+            tmpfile = mkstemp()[1]
+            with open(tmpfile, 'w') as tempfile:
+                tempfile.write("Paste your BitShuffle packets in this file. " +
+                               "You do not need to delete this message.\n\n")
+                tempfile.flush()
+            subprocess.call([args.editor, tmpfile])
+            stdin = open(tmpfile, 'r')
+
+        payload, checksum_ok = decode(stdin.read())
+        try:
+            # python 3
+            stdout.buffer.write(payload)
+        except AttributeError:
+            # python 2
+            stdout.write(payload)
+
+        if is_tmp and tmpfile:
+            os.remove(tmpfile)
+
+        if checksum_ok:
+            exit_successfully()
+        else:
+            exit_with_error(302, severity=2)
 
 
 # pylint: disable=inconsistent-return-statements
@@ -142,73 +227,5 @@ def check_for_file(filename):
         return False
 
 
-PARSER = create_parser()
-ARGS = PARSER.parse_args()
-
-# Checks if no parameters were passed
-if stdin.isatty() and not argv[1:]:
-    PARSER.print_help()
-    if DEBUG:
-        exit_with_error(1, 0)
-    else:
-        exit_successfully()
-
-# Encode & Decode inference
-ARGS = infer_mode(ARGS)
-ARGS = set_defaults(ARGS)
-
-# Main
-if ARGS.encode:
-    if ARGS.compresstype not in ['bz2', 'gzip']:
-        PARSER.print_help()
-        exit_with_error(2, ARGS.compresstype)
-    elif ARGS.compresstype == 'bz2':
-        COMPRESS = bz2.compress
-    else:
-        COMPRESS = gzip.compress
-
-    for packet in encode(stdin, ARGS.chunksize, ARGS.compresslevel,
-                         COMPRESS, ARGS.message):
-        stdout.write(packet)
-        stdout.write("\n\n")
-
-    exit_successfully()
-
-# else
-# set to True for infile to be deleted after decoding
-IS_TMP = False
-if stdin.isatty():
-    # ask the user to paste the packets into $VISUAL
-    IS_TMP = True
-    if not ARGS.editor:
-        ARGS.editor = find_editor()
-
-    if not check_for_file(ARGS.editor):
-        exit_with_error(103, ARGS.editor)
-
-    if DEBUG:
-        stderr.write("editor is %s\n" % ARGS.editor)
-
-    TMPFILE = mkstemp()[1]
-    with open(TMPFILE, 'w') as tempfile:
-        tempfile.write("Paste your BitShuffle packets in this file. " +
-                       "You do not need to delete this message.\n\n")
-        tempfile.flush()
-    subprocess.call([ARGS.editor, TMPFILE])
-    stdin = open(TMPFILE, 'r')
-
-PAYLOAD, CHECKSUM_OK = decode(stdin.read())
-try:
-    # python 3
-    stdout.buffer.write(PAYLOAD)
-except AttributeError:
-    # python 2
-    stdout.write(PAYLOAD)
-
-if IS_TMP and TMPFILE:
-    os.remove(TMPFILE)
-
-if not CHECKSUM_OK:
-    exit_with_error(302, severity=2)
-
-exit_successfully()
+if __name__ == "__main__":
+    main()

--- a/bitshuffle/__main__.py
+++ b/bitshuffle/__main__.py
@@ -53,7 +53,7 @@ def create_parser():
     parser.add_argument("--compresslevel", '-l', type=int,
                         help="Compression level when encoding. " +
                         "1 is lowest, 9 is highest. Defaults to 5. " +
-                        "Ignore if specified compresstype does not support" +
+                        "Ignored if specified compresstype does not support" +
                         " multiple compression levels.")
 
     parser.add_argument("--editor", "-E",

--- a/bitshuffle/__main__.py
+++ b/bitshuffle/__main__.py
@@ -35,12 +35,13 @@ def create_parser():
     '''Argument options for CLI tool'''
     parser = argparse.ArgumentParser(description=main.__doc__)
 
-    parser.add_argument("--encode", "-e", action="store_true",
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument("--encode", "-e", action="store_true",
                         help="Generate a BitShuffle data packet from" +
                         "the input file and write it to the output.")
 
-    parser.add_argument("--decode", "-d", "-D", action="store_true",
-                        help="Extract BitShuffle data packet(s) from the " +
+    action.add_argument("--decode", "-d", "-D", action="store_true",
+                        help="Extract BitShuffle data packet(s) from " +
                         "the input file, and write the decoded file to the " +
                         "output file.")
 

--- a/bitshuffle/__main__.py
+++ b/bitshuffle/__main__.py
@@ -83,7 +83,7 @@ ASCII text suitable for transmission over common communication protocols"""
     args = parser.parse_args()
 
     # Checks if no parameters were passed
-    if not argv[1:]:
+    if not argv[1:] and stdin.isatty():
         parser.print_help()
         if DEBUG:
             exit_with_error(1, 0)
@@ -191,17 +191,9 @@ def infer_mode(args):
     if args.encode or args.decode:
         return args
 
+    # TODO: check if stdin looks like a packet (#55)
     elif any((args.compresstype, args.compresslevel,
-              args.chunksize)):
-        args.encode = True
-
-    # this is a submenu: could specify editor to compose
-    # TODO: check editor when encoding as well as decoding
-
-    elif args.editor:
-        args.decode = True
-
-    elif not stdin.isatty():
+              args.chunksize, stdin.isatty(), not argv[1:])):
         args.encode = True
 
     else:

--- a/bitshuffle/__main__.py
+++ b/bitshuffle/__main__.py
@@ -45,8 +45,7 @@ def create_parser():
                         "the input file, and write the decoded file to the " +
                         "output file.")
 
-    parser.add_argument("--version", "-v", action="store_true",
-                        help="Displays the current version of bitshuffle.")
+    parser.add_argument("--version", "-v", action="version", version=VERSION)
 
     parser.add_argument("--chunksize", "-c", type=int,
                         help="Chunk size in bytes. Defaults to 2048.")
@@ -90,10 +89,6 @@ ASCII text suitable for transmission over common communication protocols"""
             exit_with_error(1, 0)
         else:
             exit_successfully()
-
-    elif args.version:
-        print("Version: bitshuffle v{0}".format(VERSION))
-        exit_successfully()
 
     # Encode & Decode inference
     args = infer_mode(args)

--- a/scripts/test_argument_options.sh
+++ b/scripts/test_argument_options.sh
@@ -74,19 +74,6 @@ expect_usage_error -t gmander
 #        rm -f $LOG_FILE
 #fi
 
-LOG_FILE="/tmp/$(uuidgen)"
-printf "When given bad input, prints file not found... "
-$BITSHUFFLE --input /nonexistent/nope > "$LOG_FILE" 2>&1
-if grep -i 'could not open' < "$LOG_FILE" > /dev/null 2>&1 ; then
-    echo "PASSED"
-else
-    printf "FAILED\n\n"
-
-    print_log_file "$LOG_FILE"
-    TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
-    rm -f "$LOG_FILE"
-fi
-
 echo "$TESTS_FAILED tests failed."
 echo
 exit "$TESTS_FAILED"

--- a/scripts/test_argument_options.sh
+++ b/scripts/test_argument_options.sh
@@ -49,8 +49,6 @@ expect_usage_error () {
 }
 
 echo "Running argument tests..."
-printf "When run with no args, prints help... "
-expect_usage_error
 
 printf "When run with '-h', prints help... "
 expect_usage_error -h
@@ -59,6 +57,9 @@ printf "When given bad compresstype, prints help... "
 expect_usage_error -t gmander
 
 # Can't be tested non-interactively
+#printf "When run with no args, prints help... "
+#expect_usage_error
+#
 #printf "When given bad editor, prints editor not found... "
 #LOG_FILE="/tmp/`uuidgen`"
 #$BITSHUFFLE --decode --editor /nonexistent > "$LOG_FILE" 2>&1

--- a/scripts/test_end2end.sh
+++ b/scripts/test_end2end.sh
@@ -17,11 +17,10 @@
 # shellcheck disable=SC1090
 . "$(dirname "$0")/realpath.sh"
 PARENT_DIR="$(realpath_sh "$(dirname "$0")")"
-PROJECT_ROOT="$PARENT_DIR/.."
-BITSHUFFLE="$PROJECT_ROOT/wrapper.py"
+BITSHUFFLE="$PARENT_DIR/../wrapper.py"
 
-if [ ! -f "$BITSHUFFLE" ] ; then
-	echo "FATAL: '$BITSHUFFLE' does not exist"
+if [ ! -x "$BITSHUFFLE" ] ; then
+	echo "FATAL: '$BITSHUFFLE' does not exist or is not executable"
 	exit 9999
 fi
 
@@ -52,43 +51,41 @@ do_test () {
 		printf "\n\n"
 		TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
 	fi
-	rm -f "$LOG_FILE"
-	rm -f "$TEMPFILE_SRC"
-	rm -f "$TEMPFILE_DST"
+	rm -f "$LOG_FILE" "$TEMPFILE_SRC" "$TEMPFILE_DST"
 }
 
 all_tests () {
 
     printf "Basic encode/decode test... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "Basic encode/decode test (non-default message)... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --message foo | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "Basic encode/decode test (large chunk size)... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 16384 | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
 
     printf "Basic encode/decode test (small chunk size)... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 8 | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
 
     printf "Double encode/decode test... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
         $BITSHUFFLE --encode | $BITSHUFFLE --decode | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "GZIP test... "
     do_test '$BITSHUFFLE --encode --compresstype "gzip" --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "BZIP test... "
     do_test '$BITSHUFFLE --encode --compresstype "bz2" --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "Unicode test... "
     TEMPFILE_SRC="$(uuidgen)"
@@ -112,13 +109,11 @@ all_tests () {
 		printf "\n\n"
 		TESTS_FAILED="$(echo "$TESTS_FAILED + 1" | bc)"
     fi
-	rm -f "$LOG_FILE"
-	rm -f "$TEMPFILE_SRC"
-	rm -f "$TEMPFILE_DST"
+	rm -f "$LOG_FILE" "$TEMPFILE_SRC" "$TEMPFILE_DST"
 
     printf "Test infer encode from --input... "
     do_test '$BITSHUFFLE --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1'
+        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
 
     printf "Test infer decode from --output and non-tty stdin... "
     do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \

--- a/scripts/test_end2end.sh
+++ b/scripts/test_end2end.sh
@@ -111,13 +111,14 @@ all_tests () {
     fi
 	rm -f "$LOG_FILE" "$TEMPFILE_SRC" "$TEMPFILE_DST"
 
-    printf "Test infer encode from --input... "
-    do_test '$BITSHUFFLE --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+    printf "Test infer encode from no arguments and non-interactive tty... "
+    do_test '$BITSHUFFLE < "$TEMPFILE_SRC" | \
+         $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
-    printf "Test infer decode from --output and non-tty stdin... "
-    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --output "$TEMPFILE_DST"'
+    # TODO: infer encode/decode from what input looks like
+#    printf "Test infer decode from non-tty stdin... "
+#    do_test '$BITSHUFFLE --encode < "$TEMPFILE_SRC" | \
+#        $BITSHUFFLE > "$TEMPFILE_DST"'
 
 }
 

--- a/scripts/test_end2end.sh
+++ b/scripts/test_end2end.sh
@@ -57,35 +57,35 @@ do_test () {
 all_tests () {
 
     printf "Basic encode/decode test... "
-    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+    do_test '$BITSHUFFLE --encode < "$TEMPFILE_SRC" | \
+        $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
     printf "Basic encode/decode test (non-default message)... "
-    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --message foo | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+    do_test '$BITSHUFFLE --encode < "$TEMPFILE_SRC" --message foo | \
+        $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
     printf "Basic encode/decode test (large chunk size)... "
-    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 16384 | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+    do_test '$BITSHUFFLE --encode < "$TEMPFILE_SRC" --chunksize 16384 | \
+        $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
 
     printf "Basic encode/decode test (small chunk size)... "
-    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" --chunksize 8 | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+    do_test '$BITSHUFFLE --encode < "$TEMPFILE_SRC" --chunksize 8 | \
+        $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
 
     printf "Double encode/decode test... "
-    do_test '$BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
+    do_test '$BITSHUFFLE --encode < "$TEMPFILE_SRC" | \
         $BITSHUFFLE --encode | $BITSHUFFLE --decode | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+        $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
     printf "GZIP test... "
-    do_test '$BITSHUFFLE --encode --compresstype "gzip" --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+    do_test '$BITSHUFFLE --encode --compresstype "gzip" < "$TEMPFILE_SRC" | \
+        $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
     printf "BZIP test... "
-    do_test '$BITSHUFFLE --encode --compresstype "bz2" --input "$TEMPFILE_SRC" | \
-        $BITSHUFFLE --decode --output "$TEMPFILE_DST"'
+    do_test '$BITSHUFFLE --encode --compresstype "bz2" < "$TEMPFILE_SRC" | \
+        $BITSHUFFLE --decode > "$TEMPFILE_DST"'
 
     printf "Unicode test... "
     TEMPFILE_SRC="$(uuidgen)"
@@ -93,8 +93,8 @@ all_tests () {
     LOG_FILE="$(uuidgen)"
     echo '←↑→↓↔↕↖↗↘↜↛↠↢↮↹⇆⇏⇚⇼⇿∀∁∂∃∄∅∆∈∉∋∎∐∓∗√∦∯∿' > "$TEMPFILE_SRC"
     TEMPFILE_SRC_SHA="$(shasum "$TEMPFILE_SRC" 2>&1 | cut -d ' ' -f 1)"
-    $BITSHUFFLE --encode --input "$TEMPFILE_SRC" | \
-    $BITSHUFFLE --decode --output "$TEMPFILE_DST" > "$LOG_FILE" 2>&1
+    ($BITSHUFFLE --encode < "$TEMPFILE_SRC" | \
+    $BITSHUFFLE --decode > "$TEMPFILE_DST") > "$LOG_FILE" 2>&1
 	TEMPFILE_DST_SHA="$(shasum "$TEMPFILE_DST" 2>&1 | cut -d ' ' -f 1)"
 	if [ "$TEMPFILE_DST_SHA" = "$TEMPFILE_SRC_SHA" ] ; then
 		echo "PASSED"

--- a/scripts/test_win32_smoketest.ps1
+++ b/scripts/test_win32_smoketest.ps1
@@ -11,7 +11,7 @@ Write-Output "BitShuffle script is: $bitshuffle_bin"
 
 Write-Output "Testing that BitShuffle can launch without error..."
 
-& $bitshuffle_bin --version | ForEach-Object {Write-Output "`toutput: $_";}
+& $bitshuffle_bin --version
 $exitcode = $?;
 
 if ($exitcode) {
@@ -27,9 +27,9 @@ Get-Process | Out-File "rand_test_file.bin"
 $rand_file_hash = (Get-FileHash -Algorithm SHA1 -Path "rand_test_file.bin").Hash
 
 Write-Output "Testing non-pipelined encode/decode..."
-& $bitshuffle_bin --encode --input "rand_test_file.bin" --output "test_1.txt" | ForEach-Object {Write-Output "`toutput: $_";}
+& $bitshuffle_bin --encode < "rand_test_file.bin" > "test_1.txt" | ForEach-Object {Write-Output "`toutput: $_";}
 $ret1 = $?;
-& $bitshuffle_bin --decode --input "test_1.txt" --output "test_1.bin" | ForEach-Object {Write-Output "`toutput: $_";}
+& $bitshuffle_bin --decode < "test_1.txt" > "test_1.bin" | ForEach-Object {Write-Output "`toutput: $_";}
 $ret2 = $?;
 $test_hash_1 = (Get-FileHash -Algorithm SHA1 -Path "test_1.bin").Hash
 $compare_result = ($rand_file_hash -eq $test_hash_1)
@@ -44,7 +44,7 @@ if ($ret1 -and $ret2 -and $compare_result) {
 
 
 Write-Output "Testing pipelined encode/decode..."
-& $bitshuffle_bin --encode --input "rand_test_file.bin" | & $bitshuffle_bin --decode --output "test_2.bin" | ForEach-Object {Write-Output "`toutput: $_";} *>&1
+& $bitshuffle_bin --encode < "rand_test_file.bin" | & $bitshuffle_bin --decode > "test_2.bin" | ForEach-Object {Write-Output "`toutput: $_";} *>&1
 $ret1 = $?;
 $test_hash_2 = (Get-FileHash -Algorithm SHA1 -Path "test_2.bin").Hash
 $compare_result = ($rand_file_hash -eq $test_hash_2)

--- a/scripts/test_win32_smoketest.ps1
+++ b/scripts/test_win32_smoketest.ps1
@@ -27,9 +27,9 @@ Get-Process | Out-File "rand_test_file.bin"
 $rand_file_hash = (Get-FileHash -Algorithm SHA1 -Path "rand_test_file.bin").Hash
 
 Write-Output "Testing non-pipelined encode/decode..."
-& $bitshuffle_bin --encode < "rand_test_file.bin" > "test_1.txt" | ForEach-Object {Write-Output "`toutput: $_";}
+& Get-Content "rand_test_file.bin" | $bitshuffle_bin --encode > "test_1.txt" | ForEach-Object {Write-Output "`toutput: $_";}
 $ret1 = $?;
-& $bitshuffle_bin --decode < "test_1.txt" > "test_1.bin" | ForEach-Object {Write-Output "`toutput: $_";}
+& Get-Content "test_1.txt" | $bitshuffle_bin --decode > "test_1.bin" | ForEach-Object {Write-Output "`toutput: $_";}
 $ret2 = $?;
 $test_hash_1 = (Get-FileHash -Algorithm SHA1 -Path "test_1.bin").Hash
 $compare_result = ($rand_file_hash -eq $test_hash_1)
@@ -44,7 +44,7 @@ if ($ret1 -and $ret2 -and $compare_result) {
 
 
 Write-Output "Testing pipelined encode/decode..."
-& $bitshuffle_bin --encode < "rand_test_file.bin" | & $bitshuffle_bin --decode > "test_2.bin" | ForEach-Object {Write-Output "`toutput: $_";} *>&1
+& Get-Content "rand_test_file.bin" | $bitshuffle_bin --encode | $bitshuffle_bin --decode > "test_2.bin" | ForEach-Object {Write-Output "`toutput: $_";} *>&1
 $ret1 = $?;
 $test_hash_2 = (Get-FileHash -Algorithm SHA1 -Path "test_2.bin").Hash
 $compare_result = ($rand_file_hash -eq $test_hash_2)

--- a/scripts/test_win32_smoketest.ps1
+++ b/scripts/test_win32_smoketest.ps1
@@ -27,9 +27,9 @@ Get-Process | Out-File "rand_test_file.bin"
 $rand_file_hash = (Get-FileHash -Algorithm SHA1 -Path "rand_test_file.bin").Hash
 
 Write-Output "Testing non-pipelined encode/decode..."
-& Get-Content "rand_test_file.bin" | $bitshuffle_bin --encode > "test_1.txt" | ForEach-Object {Write-Output "`toutput: $_";}
+Get-Content "rand_test_file.bin" | & $bitshuffle_bin --encode > "test_1.txt" | ForEach-Object {Write-Output "`toutput: $_";}
 $ret1 = $?;
-& Get-Content "test_1.txt" | $bitshuffle_bin --decode > "test_1.bin" | ForEach-Object {Write-Output "`toutput: $_";}
+Get-Content "test_1.txt" | & $bitshuffle_bin --decode > "test_1.bin" | ForEach-Object {Write-Output "`toutput: $_";}
 $ret2 = $?;
 $test_hash_1 = (Get-FileHash -Algorithm SHA1 -Path "test_1.bin").Hash
 $compare_result = ($rand_file_hash -eq $test_hash_1)
@@ -44,7 +44,7 @@ if ($ret1 -and $ret2 -and $compare_result) {
 
 
 Write-Output "Testing pipelined encode/decode..."
-& Get-Content "rand_test_file.bin" | $bitshuffle_bin --encode | $bitshuffle_bin --decode > "test_2.bin" | ForEach-Object {Write-Output "`toutput: $_";} *>&1
+Get-Content "rand_test_file.bin" | & $bitshuffle_bin --encode | & $bitshuffle_bin --decode > "test_2.bin" | ForEach-Object {Write-Output "`toutput: $_";} *>&1
 $ret1 = $?;
 $test_hash_2 = (Get-FileHash -Algorithm SHA1 -Path "test_2.bin").Hash
 $compare_result = ($rand_file_hash -eq $test_hash_2)

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-import os
+import subprocess
 import sys
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
-os.execvp("python", ["python", "-m", "bitshuffle"] + sys.argv[1:])
+import os
+subprocess.call(["python", "-m", "bitshuffle"] + sys.argv[1:],
+                stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr,
+                cwd=os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
This is a mess of a merge, sorry about that.

Highlights:
- `--input` and `--output` have been removed completely as arguments. This simplifies logic considerably. Shell redirection (`< > |`) can be used as an alternative
- when `stdin` is not a terminal and run without arguments, default to encoding. Solves https://github.com/charlesdaniels/bitshuffle/issues/55
- `main` is no longer a function; since `__name__` will always be `__main__`, it would have always run
- many tests have been modified for compatibility. For the most part, replacing `input`/`output` with `<`/`>` was sufficient. The exceptions:
    - "When run with no args, prints help... " can no longer be tested (since this should only occur when interactive)
    - "Test infer decode from --output and non-tty stdin... " no longer makes sense to test

Note also that Powershell tests are [very broken](https://ci.appveyor.com/project/charlesdaniels/bitshuffle/build/212) and I don't know how to fix them. From the errors, it should be fairly simple, I just don't know powershell. This request should not be merged until the tests have been fixed.

Minor changes:
- `--decode` and `--encode` are now mutually exclusive. Previously, if both were specified the message would be encoded
- `--version` now uses `argparse`'s built-in `version` action
- `wrapper.py` no longer uses `execvp`; it was incompatible with shell redirection. This is not due to the change, it was just made very evident
- fixed a couple typos
- some tests have been styled a little to make them easier to read